### PR TITLE
Fix home view not scrollable

### DIFF
--- a/mobile template/views/home.html
+++ b/mobile template/views/home.html
@@ -5,25 +5,27 @@
      data-title="Home">
 
     <br />
-    <div style="float: left; width: 30%;">
-        <img src="img/Progress_spark100px.png" />
-    </div>
-
-    <div style="float: center; width: 80%;">
-        <br />
-        <br />
-        <h1>Home Page</h1>
-    </div>
-
-    <div style="float: left; width: 100%;">
-        <h3>This template is a starting point for developing a mobile app in Telerik Platform&trade; using a Progress Data Service.
+    <div style="overflow: hidden">
+        <div style="float: left; width: 30%;">
+            <img src="img/Progress_spark100px.png" />
+        </div>
+    
+        <div style="float: center; width: 80%;">
             <br />
             <br />
-            The built-in session management and data access to a Progress Data Service is a jumpstart to building your first 
-            mobile app for a Progress OpenEdge or Progress Rollbase server.
-            <br />
-            <br />
-            Please open the README.txt for instructions on how to use this template.
-        </h3>
+            <h1>Home Page</h1>
+        </div>
+    
+        <div style="float: left; width: 100%;">
+            <h3>This template is a starting point for developing a mobile app in Telerik Platform&trade; using a Progress Data Service.
+                <br />
+                <br />
+                The built-in session management and data access to a Progress Data Service is a jumpstart to building your first 
+                mobile app for a Progress OpenEdge or Progress Rollbase server.
+                <br />
+                <br />
+                Please open the README.txt for instructions on how to use this template.
+            </h3>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
The home view's height is not properly calculated and could not be scrolled in the AppBuilder's windows device simulator and probably other devices.
The provided fix is just to wrap the content in a `div` with `overflow: hidden` style.
